### PR TITLE
Fix propTypes attached to wrong element

### DIFF
--- a/src/pages/404.jsx
+++ b/src/pages/404.jsx
@@ -21,6 +21,6 @@ const ErrorPage = center => (
 
 export default ErrorPage;
 
-Container.propTypes = {
+ErrorPage.propTypes = {
   center: PropTypes.object,
 };

--- a/src/pages/about.jsx
+++ b/src/pages/about.jsx
@@ -20,6 +20,6 @@ const About = center => (
 
 export default About;
 
-Container.propTypes = {
+About.propTypes = {
   center: PropTypes.object,
 };


### PR DESCRIPTION
In `404` and `about` page, the `propTypes` were declared on the Container element.
