### PR TITLE
Fix eslint configuration

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,27 +8,30 @@
   "rules": {
     "strict": 0,
     "no-console": "warn",
-    "quotes": [
-      "warn",
-      "single"
-    ],
-    "no-unused-vars": [
-      1
-    ],
+    "quotes": ["warn", "single"],
+    "no-unused-vars": [1],
     "react/jsx-filename-extension": [
       1,
       {
         "extensions": [".js", ".jsx"]
       }
     ],
-    "prettier/prettier": ["warn", "error", {
-     "endOfLine":"auto"
-   }]
+    "prettier/prettier": [
+      "warn",
+      {
+        "endOfLine": "auto"
+      }
+    ]
   },
   "extends": [
     "eslint:recommended",
     "plugin:react/recommended",
     "plugin:jsx-a11y/recommended"
   ],
-  "plugins": ["prettier", "jsx-a11y"]
+  "plugins": ["prettier", "jsx-a11y"],
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
+  }
 }


### PR DESCRIPTION
Fix eslint errors and warning
Error:
```
 Configuration for rule "prettier/prettier" is invalid:
        Value "error" should be object.
```
  
Warning:
```
Warning: React version not specified in eslint-plugin-react settings. See https://github.com/yannickcr/eslint-plugin-react#configuration
```

Current eslint configuration was not working due to the error.
(Some formatting changes were introduced by using prettier on the file)